### PR TITLE
Fix default value for program_output

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -159,7 +159,7 @@ class falco (
   Hash $program_output = {
     'enabled'    => false,
     'keep_alive' => false,
-    'program'    => "jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/XXX",
+    'program'    => '"jq \'{text: .output}\' | curl -d @- -X POST https://hooks.slack.com/services/XXX"',
   },
   Hash $http_output = {
     'enabled'    => false,


### PR DESCRIPTION
Prior to this, the string entered in the config file was not surrounded with quotes. The lack of quotes caused falco to crash due to malformed yaml.

Applying the code in this PR resulted in the following change:

```diff
--- /etc/falco/falco.yaml	2022-05-24 08:22:38.714866683 -0700
+++ /tmp/puppet-file20220524-10920-1nohbbg	2022-05-24 13:00:55.044652236 -0700
@@ -247,7 +247,7 @@
 program_output:
   enabled: false
   keep_alive: false
-  program: jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/XXX
+  program: "jq '{text: .output}' | curl -d @- -X POST https://hooks.slack.com/services/XXX"

 http_output:
   enabled: false
```

The result is that falco is no longer crashing.

Fixes #7 
