### PR TITLE
(ITSYS-2824) Falco >= 0.34.0 Compatibility

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -132,6 +132,7 @@ The following parameters are available in the `falco` class:
 * [`webserver`](#-falco--webserver)
 * [`program_output`](#-falco--program_output)
 * [`http_output`](#-falco--http_output)
+* [`driver`](#-falco--driver)
 * [`package_ensure`](#-falco--package_ensure)
 * [`service_ensure`](#-falco--service_ensure)
 * [`service_enable`](#-falco--service_enable)
@@ -357,13 +358,23 @@ Default value:
   }
 ```
 
+##### <a name="-falco--driver"></a>`driver`
+
+Data type: `Enum['bpf', 'modern-bpf', 'kmod']`
+
+The desired Falco driver.
+Can be one of "bpf", "modern-bpf", "kmod".
+Defaults to "kmod"
+
+Default value: `'kmod'`
+
 ##### <a name="-falco--package_ensure"></a>`package_ensure`
 
 Data type: `String[1]`
 
 A string to be passed to the package resource's ensure parameter
 
-Default value: `'installed'`
+Default value: `'>= 0.34'`
 
 ##### <a name="-falco--service_ensure"></a>`service_ensure`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -10,7 +10,7 @@
 * [`falco::config`](#falco--config): Controls the contents of falco.yaml and sets up log rotate, if needed
 * [`falco::install`](#falco--install): Installs the falco package
 * [`falco::repo`](#falco--repo): Manages the repository falco is installed from
-* [`falco::service`](#falco--service): Controls the state of the falco service
+* [`falco::service`](#falco--service): Controls the state of the falco and falcoctl services
 
 ## Classes
 
@@ -137,6 +137,7 @@ The following parameters are available in the `falco` class:
 * [`service_ensure`](#-falco--service_ensure)
 * [`service_enable`](#-falco--service_enable)
 * [`service_restart`](#-falco--service_restart)
+* [`auto_ruleset_updates`](#-falco--auto_ruleset_updates)
 
 ##### <a name="-falco--rules_file"></a>`rules_file`
 
@@ -400,6 +401,14 @@ Does the service support restarting?
 
 Default value: `true`
 
+##### <a name="-falco--auto_ruleset_updates"></a>`auto_ruleset_updates`
+
+Data type: `Boolean`
+
+Enable automatic rule updates?
+
+Default value: `true`
+
 ### <a name="falco--config"></a>`falco::config`
 
 Controls the contents of falco.yaml and sets up log rotate, if needed
@@ -414,5 +423,5 @@ Manages the repository falco is installed from
 
 ### <a name="falco--service"></a>`falco::service`
 
-Controls the state of the falco service
+Controls the state of the falco and falcoctl services
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -10,7 +10,7 @@ class falco::config inherits falco {
       group   => 'root',
       mode    => '0644',
       require => Class['falco::install'],
-      notify  => Service['falco'],
+      notify  => Service["falco-${falco::driver}"],
       ;
     '/etc/falco/falco.yaml':
       content => template('falco/falco.yaml.erb'),

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -157,6 +157,11 @@
 #   A hash to configure the http output.
 #   See the template for available keys.
 #
+# @param [Enum['bpf', 'modern-bpf', 'kmod']] driver 
+#  The desired Falco driver.
+#  Can be one of "bpf", "modern-bpf", "kmod".
+#  Defaults to "kmod"
+#
 # @param [String[1]] package_ensure
 #   A string to be passed to the package resource's ensure parameter
 #
@@ -221,8 +226,10 @@ class falco (
     'user_agent' => '"falcosecurity/falco"',
   },
 
+  Enum['bpf', 'modern-bpf', 'kmod'] $driver = 'kmod',
+
   # Installation parameters
-  String[1] $package_ensure = 'installed',
+  String[1] $package_ensure = '>= 0.34',
 
   # Service parameters
   Variant[Boolean, Enum['running', 'stopped']] $service_ensure = 'running',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -174,6 +174,9 @@
 # @param [Boolean] service_restart
 #    Does the service support restarting?
 #
+# @param [Boolean] auto_ruleset_updates
+#    Enable automatic rule updates?
+#
 #
 class falco (
   # Configuration parameters
@@ -235,6 +238,7 @@ class falco (
   Variant[Boolean, Enum['running', 'stopped']] $service_ensure = 'running',
   Boolean $service_enable = true,
   Boolean $service_restart = true,
+  Boolean $auto_ruleset_updates = true,
 ) {
   Class['falco::repo']
   -> Class['falco::install']

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,20 @@
 # Installs the falco package
 #
 class falco::install inherits falco {
+  # Install dependencies
+  $_suse_kernel_version = regsubst($facts['kernelrelease'], '^(.*)-default$', '\\1')
+  $_running_kernel_package = $facts['os']['family'] ? {
+    'Debian' => "linux-headers-${facts['kernelrelease']}",
+    'RedHat' => "kernel-devel-${facts['kernelrelease']}",
+    'Suse'   => "kernel-default-devel-${_suse_kernel_version}",
+    default  => fail("The module \"${module_name}\" does not yet support \"${facts['os']['family']}\""),
+  }
+
+  $_package_deps = ['dkms', 'make', $_running_kernel_package]
+  ensure_packages($_package_deps)
+
   package { 'falco':
-    ensure => $falco::package_ensure,
+    ensure  => $falco::package_ensure,
+    require => Package[$_package_deps],
   }
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,20 +3,48 @@
 # Installs the falco package
 #
 class falco::install inherits falco {
-  # Install dependencies
-  $_suse_kernel_version = regsubst($facts['kernelrelease'], '^(.*)-default$', '\\1')
-  $_running_kernel_package = $facts['os']['family'] ? {
-    'Debian' => "linux-headers-${facts['kernelrelease']}",
-    'RedHat' => "kernel-devel-${facts['kernelrelease']}",
-    'Suse'   => "kernel-default-devel-${_suse_kernel_version}",
-    default  => fail("The module \"${module_name}\" does not yet support \"${facts['os']['family']}\""),
+  package { 'falco':
+    ensure => $falco::package_ensure,
   }
 
-  $_package_deps = ['dkms', 'make', $_running_kernel_package]
-  ensure_packages($_package_deps)
+  # Install driver dependencies
+  # Dependencies are not required for modern-bpf driver
+  unless $falco::driver == 'modern-bpf' {
+    $_suse_kernel_version_sans_default = regsubst($facts['kernelrelease'], '^(.*)-default$', '\\1')
+    $_running_kernel_devel_package = $facts['os']['family'] ? {
+      'Debian' => "linux-headers-${facts['kernelrelease']}",
+      'RedHat' => "kernel-devel-${facts['kernelrelease']}",
+      'Suse'   => "kernel-default-devel-${_suse_kernel_version_sans_default}",
+      default  => fail("The module \"${module_name}\" does not yet support \"${facts['os']['family']}\""),
+    }
+    ensure_packages([$_running_kernel_devel_package], { 'before' => Package['falco'] })
 
-  package { 'falco':
-    ensure  => $falco::package_ensure,
-    require => Package[$_package_deps],
+    $_package_deps = ['dkms', 'make']
+    ensure_packages($_package_deps, { 'before' => Package['falco'] })
+
+    $_driver_type = $falco::driver ? {
+      'kmod'  => 'module',
+      'bpf'   => 'bpf',
+      default => fail("The drvier \"${falco::driver}\" is not yet supported by either the module \"${module_name}\" or \"falco-driver-loader\""), # lint:ignore:140chars
+    }
+
+    # Download and compile the desired falco driver based on the currently running kernel version.
+    # Recompile if the running kernel version change or falco package changes.
+    #
+    # Note, the default "--compile" flag should not be needed, but there appears to be a bug.
+    # Open issue at https://github.com/falcosecurity/falco/issues/2431
+    $_kernel_mod_path = $facts['os']['family'] ? {
+      'Debian' => "/lib/modules/${facts['kernelrelease']}/updates/dkms/falco.ko",
+      'RedHat' => "/lib/modules/${facts['kernelrelease']}/extra/falco.ko.xz",
+      'Suse'   => "/lib/modules/${facts['kernelrelease']}/updates/falco.ko",
+      default  => fail("The module \"${module_name}\" does not yet support \"${facts['os']['family']}\""),
+    }
+
+    exec { "falco-driver-loader ${_driver_type} --compile":
+      creates   => $_kernel_mod_path,
+      path      => '/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin',
+      subscribe => Package[$_running_kernel_devel_package, 'falco'],
+      notify    => Service["falco-${falco::driver}"],
+    }
   }
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -21,8 +21,6 @@ class falco::repo inherits falco {
         release  => 'stable',
         repos    => 'main',
       }
-
-      ensure_packages(["linux-headers-${facts['kernelrelease']}"])
     }
     'RedHat': {
       include 'epel'
@@ -36,8 +34,6 @@ class falco::repo inherits falco {
         enabled  => 1,
         gpgcheck => 0,
       }
-
-      ensure_packages(["kernel-devel-${facts['kernelrelease']}"])
     }
     'Suse': {
       if $facts['os']['release']['full'] == '12.5' {
@@ -72,8 +68,6 @@ class falco::repo inherits falco {
         repo_gpgcheck => 0,
         enabled       => 1,
       }
-
-      ensure_packages(['kernel-default-devel'])
     }
     default: {
       fail("\"${module_name}\" provides no repository information for OSfamily \"${facts['os']['family']}\"")

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,6 +1,6 @@
-# @summary Controls the state of the falco service
+# @summary Controls the state of the falco and falcoctl services
 #
-# Controls the state of the falco service
+# Controls the state of the falco and falcoctl services
 #
 class falco::service inherits falco {
   service { "falco-${falco::driver}":
@@ -8,5 +8,14 @@ class falco::service inherits falco {
     enable     => $falco::service_enable,
     hasstatus  => true,
     hasrestart => $falco::service_restart,
+  }
+
+  # Stop and mask the automatic ruleset updates service if automatic ruleset
+  # updates are disabled. Otherwise, it's state is managed by the falco service.
+  unless $falco::auto_ruleset_updates {
+    service { 'falcoctl-artifact-follow':
+      ensure => 'stopped',
+      enable => 'mask',
+    }
   }
 }

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,7 +3,7 @@
 # Controls the state of the falco service
 #
 class falco::service inherits falco {
-  service { 'falco':
+  service { "falco-${falco::driver}":
     ensure     => $falco::service_ensure,
     enable     => $falco::service_enable,
     hasstatus  => true,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -101,6 +101,16 @@ describe 'falco' do
         it { is_expected.to contain_service("falco-#{driver}") }
       end
 
+      context 'with auto_ruleset_updates disabled' do
+        let(:params) do
+          {
+            'auto_ruleset_updates' => false
+          }
+        end
+
+        it { is_expected.to contain_service('falcoctl-artifact-follow').with_ensure('stopped').with_enable('mask') }
+      end
+
       context 'with file_output defined' do
         let(:params) do
           {

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -6,6 +6,7 @@ describe 'falco' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) { facts }
+      let(:suse_kernel_patch_level) { '120' }
 
       context 'with defaults for all parameters' do
         it { is_expected.to compile.with_all_deps }
@@ -22,6 +23,9 @@ describe 'falco' do
 
         it { is_expected.to contain_class('falco::repo') }
 
+        it { is_expected.to contain_package('dkms') }
+        it { is_expected.to contain_package('make') }
+
         case facts[:os]['family']
         when 'Debian'
           it { is_expected.to contain_apt__key('falcosecurity') }
@@ -33,7 +37,7 @@ describe 'falco' do
           it { is_expected.to contain_package("kernel-devel-#{facts[:kernelrelease]}") }
         when 'Suse'
           it { is_expected.to contain_zypprepo('falcosecurity-rpm') }
-          it { is_expected.to contain_package('kernel-default-devel') }
+          it { is_expected.to contain_package("kernel-default-devel-#{facts[:kernelversion]}-#{suse_kernel_patch_level}") }
           it { is_expected.to contain_rpmkey('4021833E14CB7A8D') }
 
           case facts[:os]['release']['full']

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -63,7 +63,18 @@ describe 'falco' do
         }
 
         it { is_expected.to contain_class('falco::service') }
-        it { is_expected.to contain_service('falco') }
+        it { is_expected.to contain_service('falco-kmod') }
+      end
+
+      context 'with alternate driver' do
+        let(:driver) { 'bpf' }
+        let(:params) do
+          {
+            'driver' => driver
+          }
+        end
+
+        it { is_expected.to contain_service("falco-#{driver}") }
       end
 
       context 'with file_output defined' do


### PR DESCRIPTION
#### Pull Request (PR) description
Adds minimum compatibility for Falco >= 0.34, so that the service will actually start, per the docs:
- https://falco.org/docs/getting-started/installation/#installation-without-dialog-manual-configuration
- https://falco.org/docs/getting-started/running/

One of 3 drivers are available, which also determines which service to run.

As part of the updated package, also add the ability to manage automatic rule updates per https://falco.org/docs/getting-started/installation/#rule-update