### PR TITLE
Fix: Add missing dependencies when building bpf probe

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -138,6 +138,7 @@ The following parameters are available in the `falco` class:
 * [`service_enable`](#-falco--service_enable)
 * [`service_restart`](#-falco--service_restart)
 * [`auto_ruleset_updates`](#-falco--auto_ruleset_updates)
+* [`manage_dependencies`](#-falco--manage_dependencies)
 
 ##### <a name="-falco--rules_file"></a>`rules_file`
 
@@ -406,6 +407,14 @@ Default value: `true`
 Data type: `Boolean`
 
 Enable automatic rule updates?
+
+Default value: `true`
+
+##### <a name="-falco--manage_dependencies"></a>`manage_dependencies`
+
+Data type: `Boolean`
+
+Enable managing of dependencies?
 
 Default value: `true`
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -417,6 +417,8 @@ Data type: `Boolean`
 
 Enable managing of dependencies?
 
+Default value: `true`
+
 ##### <a name="-falco--manage_repo"></a>`manage_repo`
 
 Data type: `Boolean`

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -177,6 +177,8 @@
 # @param [Boolean] auto_ruleset_updates
 #    Enable automatic rule updates?
 #
+# @param manage_dependencies
+#    Enable managing of dependencies?
 #
 class falco (
   # Configuration parameters
@@ -239,6 +241,7 @@ class falco (
   Boolean $service_enable = true,
   Boolean $service_restart = true,
   Boolean $auto_ruleset_updates = true,
+  Boolean $manage_dependencies = true,
 ) {
   Class['falco::repo']
   -> Class['falco::install']

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,8 +19,13 @@ class falco::install inherits falco {
     }
     ensure_packages([$_running_kernel_devel_package], { 'before' => Package['falco'] })
 
-    $_package_deps = ['dkms', 'make']
-    ensure_packages($_package_deps, { 'before' => Package['falco'] })
+    if $falco::driver == 'kmod' {
+      $_package_deps = ['dkms', 'make']
+      ensure_packages($_package_deps, { 'before' => Package['falco'] })
+    } elsif $falco::driver == 'bpf' {
+      $_bpf_package_deps = ['llvm','clang','make']
+      ensure_packages($_bpf_package_deps, { 'before' => Package['falco']})
+    }
 
     $_driver_type = $falco::driver ? {
       'kmod'  => 'module',

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -24,7 +24,7 @@ class falco::install inherits falco {
       ensure_packages($_package_deps, { 'before' => Package['falco'] })
     } elsif $falco::driver == 'bpf' {
       $_bpf_package_deps = ['llvm','clang','make']
-      ensure_packages($_bpf_package_deps, { 'before' => Package['falco']})
+      ensure_packages($_bpf_package_deps, { 'before' => Package['falco'] })
     }
 
     $_driver_type = $falco::driver ? {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -19,11 +19,10 @@ class falco::install inherits falco {
     }
     ensure_packages([$_running_kernel_devel_package], { 'before' => Package['falco'] })
 
-    if $falco::driver == 'kmod' {
+    if $falco::manage_dependencies {
       $_package_deps = ['dkms', 'make']
       ensure_packages($_package_deps, { 'before' => Package['falco'] })
-    } elsif $falco::driver == 'bpf' {
-      $_bpf_package_deps = ['llvm','clang','make']
+      $_bpf_package_deps = ['llvm','clang']
       ensure_packages($_bpf_package_deps, { 'before' => Package['falco'] })
     }
 

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -25,6 +25,8 @@ describe 'falco' do
 
         it { is_expected.to contain_package('dkms') }
         it { is_expected.to contain_package('make') }
+        it { is_expected.to contain_package('llvm') }
+        it { is_expected.to contain_package('clang') }
 
         case facts[:os]['family']
         when 'Debian'
@@ -75,9 +77,6 @@ describe 'falco' do
           }
         end
 
-        it { is_expected.to contain_package('make') }
-        it { is_expected.to contain_package('llvm') }
-        it { is_expected.to contain_package('clang') }
         it { is_expected.to contain_exec("falco-driver-loader #{driver} --compile") }
         it { is_expected.to contain_service("falco-#{driver}") }
       end

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -75,6 +75,9 @@ describe 'falco' do
           }
         end
 
+        it { is_expected.to contain_package('make') }
+        it { is_expected.to contain_package('llvm') }
+        it { is_expected.to contain_package('clang') }
         it { is_expected.to contain_exec("falco-driver-loader #{driver} --compile") }
         it { is_expected.to contain_service("falco-#{driver}") }
       end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Added missing dependencies(llvm,clang) necessary for when running falco-driver-loader with bpf option.

#### This Pull Request (PR) fixes the following issues
n/a
