### PR TITLE
Fix falco-driver-loader bpf

### DIFF
--- a/lib/facter/falco.rb
+++ b/lib/facter/falco.rb
@@ -1,0 +1,9 @@
+Facter.add(:falco_driver_version) do
+  confine :kernel => :Linux
+  setcode do
+    if Facter::Util::Resolution.which('falco')
+      falco_driver_version = Facter::Util::Resolution.exec('falco --version')
+      falco_driver_version.match(/\d+\.\d+\.\d+\+driver/).to_s
+    end
+  end
+end

--- a/lib/facter/falco.rb
+++ b/lib/facter/falco.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 Facter.add(:falco_driver_version) do
-  confine :kernel => :Linux
+  confine kernel: :Linux
+  confine Facter::Util::Resolution.which('falco')
+
   setcode do
-    if Facter::Util::Resolution.which('falco')
-      falco_driver_version = Facter::Util::Resolution.exec('falco --version')
-      falco_driver_version.match(/\d+\.\d+\.\d+\+driver/).to_s
-    end
+    falco_driver_version = Facter::Util::Resolution.exec('falco --version')
+    falco_driver_version.match(%r{\d+\.\d+\.\d+\+driver}).to_s
   end
 end

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -51,7 +51,7 @@ class falco::install inherits falco {
       }
       'bpf': {
         exec { "falco-driver-loader ${_driver_type} --compile":
-          creates     => "/root/.falco/${facts['falco_driver_version']}/${facts['os']['architecture']}/falco_${downcase($::operatingsystem)}_${facts['kernelrelease']}_1.o", # lint:ignore:140chars
+          creates     => "/root/.falco/${facts['falco_driver_version']}/${facts['os']['architecture']}/falco_${downcase($facts['os']['name'])}_${facts['kernelrelease']}_1.o", # lint:ignore:140chars
           environment => ['HOME=/root'],
           path        => '/usr/local/sbin:/usr/sbin:/sbin:/usr/local/bin:/usr/bin:/bin',
           subscribe   => Package[$_running_kernel_devel_package, 'falco'],

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -68,6 +68,11 @@ describe 'falco' do
       end
 
       context 'with bpf driver' do
+        let(:facts) do
+          facts.merge(
+            { falco_driver_version: '5.0.1+driver' }
+          )
+        end
         let(:driver) { 'bpf' }
         let(:params) do
           {
@@ -75,7 +80,12 @@ describe 'falco' do
           }
         end
 
-        it { is_expected.to contain_exec("falco-driver-loader #{driver} --compile") }
+        it {
+          is_expected.to contain_exec("falco-driver-loader #{driver} --compile").with(
+            { creates: "/root/.falco/5.0.1+driver/#{facts[:architecture]}/falco_#{facts[:operatingsystem].downcase}_#{facts[:kernelrelease]}_1.o" }
+          )
+        }
+
         it { is_expected.to contain_service("falco-#{driver}") }
       end
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Added another exec for when building the bpf probe. This is because the falco-driver-loader bpf command looks in the home folder of the user that runs falco(root) to see if theres already a probe existent. Therefore when running puppet and no home folder exists, it will put the driver in the wrong location.



#### This Pull Request (PR) fixes the following issues
Falco could not detect if a bpf probe was available, because upon running the falco-driver-loader command the bpf probe would be put in the wrong location.
