### PR TITLE
Make falco file output really optional

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -22,7 +22,7 @@ class falco::config inherits falco {
 
   $_file_output = $falco::file_output
 
-  if ($_file_output != undef) {
+  if ($_file_output != undef) and ($_file_output['enabled']) {
     logrotate::rule { 'falco_output':
       path          => $_file_output['filename'],
       rotate        => 5,

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -125,6 +125,19 @@ describe 'falco' do
         it { is_expected.to contain_logrotate__rule('falco_output').with_path('/var/log/somefolder/falco-events.log') }
       end
 
+      context 'with file_output disabled' do
+        let(:params) do
+          {
+            'file_output' => {
+              'enabled' => false,
+            }
+          }
+        end
+
+        it { is_expected.not_to contain_class('logrotate::rule') }
+        it { is_expected.not_to contain_logrotate__rule('falco_output') }
+      end
+
       context 'with local_rules value specified' do
         # rubocop:disable Style/WordArray
         let(:params) do


### PR DESCRIPTION
Based on the behavior of the `falco::config` class, it seems like this was the original intention.